### PR TITLE
Don't break seeds without a Stripe API key

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,15 @@ Feed::Entry.transaction do
   end
 end
 
-Stripe::Customer.list.each do |stripe_customer|
+customers = begin
+  Stripe::Customer.list
+rescue Stripe::StripeError => e
+  puts "Seeds will not include Stripe customers."
+  puts e
+  []
+end
+
+customers.each do |stripe_customer|
   user = User.find_by(email: stripe_customer.email)
   next unless user
 


### PR DESCRIPTION
If a Stripe API key is missing, `bin/setup` should still work (according to the README).
In that case, simply warn that seeds will be added to the database with the exception of Stripe customers.