### PR TITLE
Fix Dockerfile for ESBuild to Vite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,7 @@ FROM base
 
 COPY . .
 COPY --from=build /usr/local/bundle /usr/local/bundle
-COPY --from=build /rails/app/assets /rails/app/assets
-COPY --from=build /rails/public/assets /rails/public/assets
+COPY --from=build /rails/public /rails/public
 
 RUN bundle exec bootsnap precompile --gemfile /app /lib
 


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/ksylvest/playground/pull/5488 w/ Dockerfile not properly copying everything in public.